### PR TITLE
spring profile 구분, dockerfile 세팅

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM adoptopenjdk/openjdk11:alpine
-ARG JAR_FILE
+ARG JAR_FILE=build/libs/\*.jar
+ARG PROFILE=local-docker
+ENV PROFILE_ENV ${PROFILE}
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java", "-jar", "/app.jar", "--spring.profiles.active=prod"]
+ENTRYPOINT ["java", "-jar", "/app.jar", "--spring.profiles.active=${PROFILE_ENV}"]

--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
 	implementation 'net.rakugakibox.util:yaml-resource-bundle:1.1'
-	implementation 'org.springframework.boot:spring-boot-devtools'
+//	implementation 'org.springframework.boot:spring-boot-devtools'
 
 	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+//	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,15 @@
+# 공통
+
+server:
+  port: 8082
+
 spring:
+  profiles:
+    active: local   # 프로파일 지정 없으면 디폴트로 local 사용
   datasource:
-    url: jdbc:mariadb://localhost:3306/board
     driver-class-name: org.mariadb.jdbc.Driver
     username: root
-    password: draw
+    password: mariadb
   mvc:
     hiddenmethod:
       filter:
@@ -12,19 +18,30 @@ spring:
     open-in-view: false
     generate-ddl: true
     show-sql: true
-    hibernate:
-      ddl-auto: update
-
+#    아래 선언시 -> 구동시 ddl create, 종료시 ddl drop
+#    hibernate:
+#      ddl-auto: update
   jwt:
     secret: 2021!!ZorupMSA
-
   messages:
     basename: i18n/exception
     encoding: UTF-8
+---
 
-  devtools:
-    livereload:
-      enabled: true
+# 로컬 IDE기반 개발용 프로파일
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:mariadb://localhost:3306/test
 
-server:
-  port: 8082
+---
+
+## 로컬에서 도커로 띄워놓을때 사용하는 프로파일
+spring:
+  config:
+    activate:
+      on-profile: local-docker
+  datasource:
+    url: jdbc:mariadb://host.docker.internal:3306/test


### PR DESCRIPTION
1. local에서 서버를 IDE로 키지 않고 container로 켜놓을 수 있게 하기 위해 local container용 spring profile 설정.
2. Docker build 편리하게 할 수 있도록 Dockerfile 작성